### PR TITLE
Update .gitignore: exclude DBs, history.txt, venv, cache, and Playwright/test output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -192,3 +192,16 @@ cython_debug/
 #  refer to https://docs.cursor.com/context/ignore-files
 .cursorignore
 .cursorindexingignore
+
+# Project-specific ignores
+coffee.db
+coffee_test.db
+history.txt
+__pycache__/
+.venv/
+
+# Ignore Playwright output (if any)
+test-results/
+
+# Ignore local VS Code settings (uncomment if desired)
+#.vscode/


### PR DESCRIPTION
- Added project-specific ignores for SQLite DBs (coffee.db, coffee_test.db), history.txt, Python cache directories, .venv, and Playwright/test output folders.
- Ensures only necessary files are committed to the repository.
- No application logic or test code changed. Safe housekeeping update for repo hygiene.